### PR TITLE
Fixing creation of rule when multiple icmp_type are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.5.2 (2024-09-02)
+
+[Full Changelog](https://github.com/webalexeu/puppet-windows_firewall/compare/v1.5.1...v1.5.2)
+
+**Features**
+
+**Bugfixes**
+
+- [Cannot create rule when multiple icmp_type are defined](https://github.com/webalexeu/puppet-windows_firewall/issues/33)
+
+**Known Issues**
+
 ## Release 1.5.1 (2024-08-24)
 
 [Full Changelog](https://github.com/webalexeu/puppet-windows_firewall/compare/v1.5.0...v1.5.1)
@@ -13,6 +25,8 @@ All notable changes to this project will be documented in this file.
 - [Cannot define mutlitple icmp_type](https://github.com/webalexeu/puppet-windows_firewall/issues/31)
 
 **Known Issues**
+
+- Cannot create rule when multiple icmp_type are defined
 
 ## Release 1.5.0 (2024-06-07)
 

--- a/lib/ps/windows_firewall/ps-bridge.ps1
+++ b/lib/ps/windows_firewall/ps-bridge.ps1
@@ -167,12 +167,12 @@ function create {
     if ($ProtocolCode) {
         $params.Add("ProtocolCode", $ProtocolCode)
     }
-    if ($IcmpType) {
-        $params.Add("IcmpType", $IcmpType)
-    }
-    # `$LocalPort` and `$RemotePort` will always be strings since we were
+    # `$IcmpType, `$LocalPort` and `$RemotePort` will always be strings since we were
     # invoked with `powershell -File`, rather then refactor the loader to use
     # `-Command`, just do a simple string split
+    if ($IcmpType) {
+        $params.Add("IcmpType", ($IcmpType -split ','))
+    }
     if ($LocalPort) {
         $params.Add("LocalPort", ($LocalPort -split ','))
     }
@@ -268,12 +268,12 @@ function update {
     if ($ProtocolCode) {
         $params.Add("ProtocolCode", $ProtocolCode)
     }
+    # `$IcmpType, `$LocalPort` and `$RemotePort` will always be strings since we were
+    # invoked with `powershell -File`, rather then refactor the loader to use
+    # `-Command`, just do a simple string split
     if ($IcmpType) {
         $params.Add("IcmpType", ($IcmpType -split ','))
     }
-    # `$LocalPort` and `$RemotePort` will always be strings since we were
-    # invoked with `powershell -File`, rather then refactor the loader to use
-    # `-Command`, just do a simple string split
     if ($LocalPort) {
         $params.Add("LocalPort", ($LocalPort -split ','))
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "webalex-windows_firewall",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": "webalex",
   "summary": "Manage the windows firewall with Puppet",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Fix https://github.com/webalexeu/puppet-windows_firewall/issues/33

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)